### PR TITLE
Added GT2560 Rev. A (EFB) board definition

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -97,6 +97,7 @@
 #define BOARD_SCOOVO_X9H        321   // abee Scoovo X9H
 #define BOARD_GT2560_REV_A      74    // Geeetech GT2560 Rev. A
 #define BOARD_GT2560_REV_A_PLUS 75    // Geeetech GT2560 Rev. A+ (with auto level probe)
+#define BOARD_GT2560_REV_A_EFB  76   // Geeetech GT2560 Rev. A (Power outputs: Hotend, Fan, Bed)
 
 //
 // ATmega1281, ATmega2561


### PR DESCRIPTION
Added a new definition for Geeetech GT2560 Rev. A EFB board pins.

EFB means Hotend, Fan, Bed power outputs.  (This is similar to RAMPS boards)

I did this beacause  my printer do not own a second extruder, so i use it's output for a 80x80 bed fan that is used for fast cooling the material at the end of the gcode printing. 

The noted advantages are:

1.  should prevent material warping while cooling.

2.  the difference in contraction between the plastic and the glass in cooling causes the object to detach itself from the surface of the support bed, leaving the first layer of plastic without deformation. (In practice there is no need for a scoop to detach it from the plate).

3.  Drastically reduced waiting times.

Below an image of my bed withthe fan. Thant's all!
![80x80_bed_fan](https://user-images.githubusercontent.com/13614344/37885305-c7c68c48-30b4-11e8-97a1-189288d91e27.jpg)
