### PR TITLE
Added GT2560 Rev. A (EFB) board definition

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -97,6 +97,7 @@
 #define BOARD_SCOOVO_X9H        321   // abee Scoovo X9H
 #define BOARD_GT2560_REV_A      74    // Geeetech GT2560 Rev. A
 #define BOARD_GT2560_REV_A_PLUS 75    // Geeetech GT2560 Rev. A+ (with auto level probe)
+#define BOARD_GT2560_REV_A_EFB  76    // Geeetech GT2560 Rev. A (Power outputs: Hotend, Fan, Bed)
 
 //
 // ATmega1281, ATmega2561

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -170,6 +170,8 @@
   #include "pins_GT2560_REV_A.h"      // ATmega1280, ATmega2560
 #elif MB(GT2560_REV_A_PLUS)
   #include "pins_GT2560_REV_A_PLUS.h" // ATmega1280, ATmega2560
+#elif MB(GT2560_REV_A_EFB)
+  #include "pins_GT2560_REV_A_EFB.h"  // ATmega1280, ATmega2560
 #elif MB(SILVER_GATE)
   #include "pins_SILVER_GATE.h"       // ATmega2561
 

--- a/Marlin/pins_GT2560_REV_A_EFB.h
+++ b/Marlin/pins_GT2560_REV_A_EFB.h
@@ -1,0 +1,45 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Geeetech GT2560 Revision A board pin assignments, based on the work of
+ * George Robles (https://georges3dprinters.com) and
+ * Richard Smith <galorin@gmail.com>
+ */
+
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__)
+  #error "Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu."
+#endif
+
+#ifndef BOARD_NAME
+  #define BOARD_NAME "GT2560 Rev.A (efb)"
+#endif
+
+#include "pins_GT2560_REV_A.h"
+
+
+//
+// Heaters / Fans
+//
+#undef HEATER_1_PIN
+#define FAN1_PIN            3 //use fan_1 on pin 3 instead of heater_1
+


### PR DESCRIPTION
Added a new definition for Geeetech GT2560 Rev. A EFB board pins.

_EFB_ means **Hotend, Fan, Bed power outputs**. (This is similar to RAMPS boards)

I did this beacause my printer do not own a second extruder, so i use it's output for a 80x80 bed fan that generate a fast cooling on the material at the end of the gcode printing.

The noted advantages are:

1. 	should prevent material warping while cooling;
2. 	the difference in contraction between the plastic and the glass in cooling causes the object to detach itself from the surface of the support bed, leaving the first layer of plastic without deformation. (In practice there is no need for a scoop to detach it from the plate);
3. 	Drastically reduced cooling waiting times.

Below an image of my bed with the fan. Thant's all!

![80x80_bed_fan](https://user-images.githubusercontent.com/13614344/37886430-a831f96a-30bb-11e8-84ec-a849f9cd9f40.jpg)
